### PR TITLE
chore: adjust where we place the reportMissingModuleSource rule ignore

### DIFF
--- a/examples/generators/production_python_smart_contract_python/.vscode/settings.json
+++ b/examples/generators/production_python_smart_contract_python/.vscode/settings.json
@@ -14,6 +14,9 @@
   
   // Python
   "python.analysis.extraPaths": ["${workspaceFolder}/smart_contracts"],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingModuleSource": "none"
+  },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.codeActionsOnSave": {

--- a/examples/generators/production_python_smart_contract_python/smart_contracts/hello_world/contract.py
+++ b/examples/generators/production_python_smart_contract_python/smart_contracts/hello_world/contract.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingModuleSource=false
 from algopy import ARC4Contract, arc4
 
 

--- a/examples/generators/production_python_smart_contract_typescript/.vscode/settings.json
+++ b/examples/generators/production_python_smart_contract_typescript/.vscode/settings.json
@@ -17,6 +17,9 @@
   
   // Python
   "python.analysis.extraPaths": ["${workspaceFolder}/smart_contracts"],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingModuleSource": "none"
+  },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.codeActionsOnSave": {

--- a/examples/generators/production_python_smart_contract_typescript/smart_contracts/hello_world/contract.py
+++ b/examples/generators/production_python_smart_contract_typescript/smart_contracts/hello_world/contract.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingModuleSource=false
 from algopy import ARC4Contract, arc4
 
 

--- a/examples/generators/starter_python_smart_contract_python/.vscode/settings.json
+++ b/examples/generators/starter_python_smart_contract_python/.vscode/settings.json
@@ -14,6 +14,9 @@
   
   // Python
   "python.analysis.extraPaths": ["${workspaceFolder}/smart_contracts"],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingModuleSource": "none"
+  },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.codeActionsOnSave": {

--- a/examples/generators/starter_python_smart_contract_python/smart_contracts/hello_world/contract.py
+++ b/examples/generators/starter_python_smart_contract_python/smart_contracts/hello_world/contract.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingModuleSource=false
 from algopy import ARC4Contract, arc4
 
 

--- a/examples/generators/starter_python_smart_contract_typescript/.vscode/settings.json
+++ b/examples/generators/starter_python_smart_contract_typescript/.vscode/settings.json
@@ -17,6 +17,9 @@
   
   // Python
   "python.analysis.extraPaths": ["${workspaceFolder}/smart_contracts"],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingModuleSource": "none"
+  },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.codeActionsOnSave": {

--- a/examples/generators/starter_python_smart_contract_typescript/smart_contracts/hello_world/contract.py
+++ b/examples/generators/starter_python_smart_contract_typescript/smart_contracts/hello_world/contract.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingModuleSource=false
 from algopy import ARC4Contract, arc4
 
 

--- a/examples/production_python/.vscode/settings.json
+++ b/examples/production_python/.vscode/settings.json
@@ -14,6 +14,9 @@
   
   // Python
   "python.analysis.extraPaths": ["${workspaceFolder}/smart_contracts"],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingModuleSource": "none"
+  },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.codeActionsOnSave": {

--- a/examples/production_python/smart_contracts/hello_world/contract.py
+++ b/examples/production_python/smart_contracts/hello_world/contract.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingModuleSource=false
 from algopy import ARC4Contract, arc4
 
 

--- a/examples/starter_python/.vscode/settings.json
+++ b/examples/starter_python/.vscode/settings.json
@@ -14,6 +14,9 @@
   
   // Python
   "python.analysis.extraPaths": ["${workspaceFolder}/smart_contracts"],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingModuleSource": "none"
+  },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.codeActionsOnSave": {

--- a/examples/starter_python/smart_contracts/hello_world/contract.py
+++ b/examples/starter_python/smart_contracts/hello_world/contract.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingModuleSource=false
 from algopy import ARC4Contract, arc4
 
 

--- a/template_content/smart_contracts/{{ contract_name }}/contract.py.jinja
+++ b/template_content/smart_contracts/{{ contract_name }}/contract.py.jinja
@@ -1,4 +1,3 @@
-# pyright: reportMissingModuleSource=false
 from algopy import ARC4Contract, arc4
 
 

--- a/template_content/{% if ide_vscode %}.vscode{% endif %}/settings.json.jinja
+++ b/template_content/{% if ide_vscode %}.vscode{% endif %}/settings.json.jinja
@@ -17,6 +17,9 @@
   {% endif %}
   // Python
   "python.analysis.extraPaths": ["${workspaceFolder}/smart_contracts"],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingModuleSource": "none"
+  },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.codeActionsOnSave": {


### PR DESCRIPTION
Rather than ignoring per file, ignore for the entire project.