### PR TITLE
fix: adding task to explicitly set 3.12 env by poetry

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -1,5 +1,9 @@
 _subdirectory: template_content
 _templates_suffix: ".jinja"
+_tasks:
+  - "echo '==== Explicitly setting 3.12 for poetry env ==='"
+  - 'poetry env use 3.12'
+
 
 use_workspace:
   type: bool


### PR DESCRIPTION
## Proposed Changes

- explicitly setting the env to use 3.12 to mitigate potential poetry issues with discovery of 3.12 if 3.12 is not default python.
