### PR TITLE
Optional pinning of the deployment version to the project version

### DIFF
--- a/examples/generators/production_python_smart_contract_python/smart_contracts/__main__.py
+++ b/examples/generators/production_python_smart_contract_python/smart_contracts/__main__.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from smart_contracts.config import contracts
 from smart_contracts.helpers.build import build
 from smart_contracts.helpers.deploy import deploy
-from smart_contracts.helpers.util import find_app_spec_file
+from smart_contracts.helpers.util import find_app_spec_file, find_pyproject_version
 
 # Uncomment the following lines to enable auto generation of AVM Debugger compliant sourcemap and simulation trace file.
 # Learn more about using AlgoKit AVM Debugger to debug your TEAL source codes and inspect various kinds of
@@ -27,6 +27,7 @@ root_path = Path(__file__).parent
 
 def main(action: str) -> None:
     artifact_path = root_path / "artifacts"
+    pyproject_version = find_pyproject_version(root_path.parent / "pyproject.toml")
     match action:
         case "build":
             for contract in contracts:
@@ -41,14 +42,14 @@ def main(action: str) -> None:
                     raise Exception("Could not deploy app, .arc32.json file not found")
                 app_spec_path = output_dir / app_spec_file_name
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
         case "all":
             for contract in contracts:
                 logger.info(f"Building app at {contract.path}")
                 app_spec_path = build(artifact_path / contract.name, contract.path)
                 logger.info(f"Deploying {contract.path.name}")
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
 
 
 if __name__ == "__main__":

--- a/examples/generators/production_python_smart_contract_python/smart_contracts/config.py
+++ b/examples/generators/production_python_smart_contract_python/smart_contracts/config.py
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import Account, ApplicationSpecification
 from algosdk.v2client.algod import AlgodClient
@@ -13,7 +14,7 @@ class SmartContract:
     path: Path
     name: str
     deploy: (
-        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
         | None
     ) = None
 
@@ -30,7 +31,7 @@ def import_contract(folder: Path) -> Path:
 def import_deploy_if_exists(
     folder: Path,
 ) -> (
-    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
     | None
 ):
     """Imports the deploy function from a folder if it exists."""

--- a/examples/generators/production_python_smart_contract_python/smart_contracts/hello_world/deploy_config.py
+++ b/examples/generators/production_python_smart_contract_python/smart_contracts/hello_world/deploy_config.py
@@ -13,6 +13,7 @@ def deploy(
     indexer_client: IndexerClient,
     app_spec: algokit_utils.ApplicationSpecification,
     deployer: algokit_utils.Account,
+    version: str | None,
 ) -> None:
     from smart_contracts.artifacts.hello_world.client import (
         HelloWorldClient,
@@ -27,6 +28,8 @@ def deploy(
     app_client.deploy(
         on_schema_break=algokit_utils.OnSchemaBreak.AppendApp,
         on_update=algokit_utils.OnUpdate.AppendApp,
+        # Uncomment this next line to pin the deployment version to the project version.
+        version=version,
     )
     name = "world"
     response = app_client.hello(name=name)

--- a/examples/generators/production_python_smart_contract_python/smart_contracts/helpers/deploy.py
+++ b/examples/generators/production_python_smart_contract_python/smart_contracts/helpers/deploy.py
@@ -4,6 +4,7 @@
 import logging
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import (
     Account,
@@ -24,8 +25,9 @@ logger = logging.getLogger(__name__)
 def deploy(
     app_spec_path: Path,
     deploy_callback: Callable[
-        [AlgodClient, IndexerClient, ApplicationSpecification, Account], None
+        [AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None
     ],
+    version: str | None = None,
     deployer_initial_funds: int = 2,
 ) -> None:
     # get clients
@@ -50,4 +52,4 @@ def deploy(
     )
 
     # use provided callback to deploy the app
-    deploy_callback(algod_client, indexer_client, app_spec, deployer)
+    deploy_callback(algod_client, indexer_client, app_spec, deployer, version)

--- a/examples/generators/production_python_smart_contract_python/smart_contracts/helpers/util.py
+++ b/examples/generators/production_python_smart_contract_python/smart_contracts/helpers/util.py
@@ -1,8 +1,18 @@
 from pathlib import Path
 
+import tomllib
+
 
 def find_app_spec_file(output_dir: Path) -> str | None:
     for file in output_dir.iterdir():
         if file.is_file() and file.suffixes == [".arc32", ".json"]:
             return file.name
     return None
+
+
+def find_pyproject_version(pyproject_toml: Path) -> str | None:
+    try:
+        data = tomllib.load(open(pyproject_toml, "rb"))
+        return data.get("tool", {}).get("poetry", {}).get("version")
+    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        return None

--- a/examples/generators/production_python_smart_contract_typescript/smart_contracts/config.py
+++ b/examples/generators/production_python_smart_contract_typescript/smart_contracts/config.py
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import Account, ApplicationSpecification
 from algosdk.v2client.algod import AlgodClient
@@ -13,7 +14,7 @@ class SmartContract:
     path: Path
     name: str
     deploy: (
-        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
         | None
     ) = None
 
@@ -30,7 +31,7 @@ def import_contract(folder: Path) -> Path:
 def import_deploy_if_exists(
     folder: Path,
 ) -> (
-    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
     | None
 ):
     """Imports the deploy function from a folder if it exists."""

--- a/examples/generators/production_python_smart_contract_typescript/smart_contracts/helpers/util.py
+++ b/examples/generators/production_python_smart_contract_typescript/smart_contracts/helpers/util.py
@@ -1,8 +1,18 @@
 from pathlib import Path
 
+import tomllib
+
 
 def find_app_spec_file(output_dir: Path) -> str | None:
     for file in output_dir.iterdir():
         if file.is_file() and file.suffixes == [".arc32", ".json"]:
             return file.name
     return None
+
+
+def find_pyproject_version(pyproject_toml: Path) -> str | None:
+    try:
+        data = tomllib.load(open(pyproject_toml, "rb"))
+        return data.get("tool", {}).get("poetry", {}).get("version")
+    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        return None

--- a/examples/generators/starter_python_smart_contract_python/smart_contracts/__main__.py
+++ b/examples/generators/starter_python_smart_contract_python/smart_contracts/__main__.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from smart_contracts.config import contracts
 from smart_contracts.helpers.build import build
 from smart_contracts.helpers.deploy import deploy
-from smart_contracts.helpers.util import find_app_spec_file
+from smart_contracts.helpers.util import find_app_spec_file, find_pyproject_version
 
 # Uncomment the following lines to enable auto generation of AVM Debugger compliant sourcemap and simulation trace file.
 # Learn more about using AlgoKit AVM Debugger to debug your TEAL source codes and inspect various kinds of
@@ -27,6 +27,7 @@ root_path = Path(__file__).parent
 
 def main(action: str) -> None:
     artifact_path = root_path / "artifacts"
+    pyproject_version = find_pyproject_version(root_path.parent / "pyproject.toml")
     match action:
         case "build":
             for contract in contracts:
@@ -41,14 +42,14 @@ def main(action: str) -> None:
                     raise Exception("Could not deploy app, .arc32.json file not found")
                 app_spec_path = output_dir / app_spec_file_name
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
         case "all":
             for contract in contracts:
                 logger.info(f"Building app at {contract.path}")
                 app_spec_path = build(artifact_path / contract.name, contract.path)
                 logger.info(f"Deploying {contract.path.name}")
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
 
 
 if __name__ == "__main__":

--- a/examples/generators/starter_python_smart_contract_python/smart_contracts/config.py
+++ b/examples/generators/starter_python_smart_contract_python/smart_contracts/config.py
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import Account, ApplicationSpecification
 from algosdk.v2client.algod import AlgodClient
@@ -13,7 +14,7 @@ class SmartContract:
     path: Path
     name: str
     deploy: (
-        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
         | None
     ) = None
 
@@ -30,7 +31,7 @@ def import_contract(folder: Path) -> Path:
 def import_deploy_if_exists(
     folder: Path,
 ) -> (
-    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
     | None
 ):
     """Imports the deploy function from a folder if it exists."""

--- a/examples/generators/starter_python_smart_contract_python/smart_contracts/hello_world/deploy_config.py
+++ b/examples/generators/starter_python_smart_contract_python/smart_contracts/hello_world/deploy_config.py
@@ -13,6 +13,7 @@ def deploy(
     indexer_client: IndexerClient,
     app_spec: algokit_utils.ApplicationSpecification,
     deployer: algokit_utils.Account,
+    version: str | None,
 ) -> None:
     from smart_contracts.artifacts.hello_world.client import (
         HelloWorldClient,
@@ -27,6 +28,8 @@ def deploy(
     app_client.deploy(
         on_schema_break=algokit_utils.OnSchemaBreak.AppendApp,
         on_update=algokit_utils.OnUpdate.AppendApp,
+        # Uncomment this next line to pin the deployment version to the project version.
+        version=version,
     )
     name = "world"
     response = app_client.hello(name=name)

--- a/examples/generators/starter_python_smart_contract_python/smart_contracts/helpers/deploy.py
+++ b/examples/generators/starter_python_smart_contract_python/smart_contracts/helpers/deploy.py
@@ -4,6 +4,7 @@
 import logging
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import (
     Account,
@@ -24,8 +25,9 @@ logger = logging.getLogger(__name__)
 def deploy(
     app_spec_path: Path,
     deploy_callback: Callable[
-        [AlgodClient, IndexerClient, ApplicationSpecification, Account], None
+        [AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None
     ],
+    version: str | None = None,
     deployer_initial_funds: int = 2,
 ) -> None:
     # get clients
@@ -50,4 +52,4 @@ def deploy(
     )
 
     # use provided callback to deploy the app
-    deploy_callback(algod_client, indexer_client, app_spec, deployer)
+    deploy_callback(algod_client, indexer_client, app_spec, deployer, version)

--- a/examples/generators/starter_python_smart_contract_python/smart_contracts/helpers/util.py
+++ b/examples/generators/starter_python_smart_contract_python/smart_contracts/helpers/util.py
@@ -1,8 +1,18 @@
 from pathlib import Path
 
+import tomllib
+
 
 def find_app_spec_file(output_dir: Path) -> str | None:
     for file in output_dir.iterdir():
         if file.is_file() and file.suffixes == [".arc32", ".json"]:
             return file.name
     return None
+
+
+def find_pyproject_version(pyproject_toml: Path) -> str | None:
+    try:
+        data = tomllib.load(open(pyproject_toml, "rb"))
+        return data.get("tool", {}).get("poetry", {}).get("version")
+    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        return None

--- a/examples/generators/starter_python_smart_contract_typescript/smart_contracts/config.py
+++ b/examples/generators/starter_python_smart_contract_typescript/smart_contracts/config.py
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import Account, ApplicationSpecification
 from algosdk.v2client.algod import AlgodClient
@@ -13,7 +14,7 @@ class SmartContract:
     path: Path
     name: str
     deploy: (
-        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
         | None
     ) = None
 
@@ -30,7 +31,7 @@ def import_contract(folder: Path) -> Path:
 def import_deploy_if_exists(
     folder: Path,
 ) -> (
-    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
     | None
 ):
     """Imports the deploy function from a folder if it exists."""

--- a/examples/generators/starter_python_smart_contract_typescript/smart_contracts/helpers/util.py
+++ b/examples/generators/starter_python_smart_contract_typescript/smart_contracts/helpers/util.py
@@ -1,8 +1,18 @@
 from pathlib import Path
 
+import tomllib
+
 
 def find_app_spec_file(output_dir: Path) -> str | None:
     for file in output_dir.iterdir():
         if file.is_file() and file.suffixes == [".arc32", ".json"]:
             return file.name
     return None
+
+
+def find_pyproject_version(pyproject_toml: Path) -> str | None:
+    try:
+        data = tomllib.load(open(pyproject_toml, "rb"))
+        return data.get("tool", {}).get("poetry", {}).get("version")
+    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        return None

--- a/examples/production_python/smart_contracts/__main__.py
+++ b/examples/production_python/smart_contracts/__main__.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from smart_contracts.config import contracts
 from smart_contracts.helpers.build import build
 from smart_contracts.helpers.deploy import deploy
-from smart_contracts.helpers.util import find_app_spec_file
+from smart_contracts.helpers.util import find_app_spec_file, find_pyproject_version
 
 # Uncomment the following lines to enable auto generation of AVM Debugger compliant sourcemap and simulation trace file.
 # Learn more about using AlgoKit AVM Debugger to debug your TEAL source codes and inspect various kinds of
@@ -27,6 +27,7 @@ root_path = Path(__file__).parent
 
 def main(action: str) -> None:
     artifact_path = root_path / "artifacts"
+    pyproject_version = find_pyproject_version(root_path.parent / "pyproject.toml")
     match action:
         case "build":
             for contract in contracts:
@@ -41,14 +42,14 @@ def main(action: str) -> None:
                     raise Exception("Could not deploy app, .arc32.json file not found")
                 app_spec_path = output_dir / app_spec_file_name
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
         case "all":
             for contract in contracts:
                 logger.info(f"Building app at {contract.path}")
                 app_spec_path = build(artifact_path / contract.name, contract.path)
                 logger.info(f"Deploying {contract.path.name}")
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
 
 
 if __name__ == "__main__":

--- a/examples/production_python/smart_contracts/config.py
+++ b/examples/production_python/smart_contracts/config.py
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import Account, ApplicationSpecification
 from algosdk.v2client.algod import AlgodClient
@@ -13,7 +14,7 @@ class SmartContract:
     path: Path
     name: str
     deploy: (
-        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
         | None
     ) = None
 
@@ -30,7 +31,7 @@ def import_contract(folder: Path) -> Path:
 def import_deploy_if_exists(
     folder: Path,
 ) -> (
-    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
     | None
 ):
     """Imports the deploy function from a folder if it exists."""

--- a/examples/production_python/smart_contracts/hello_world/deploy_config.py
+++ b/examples/production_python/smart_contracts/hello_world/deploy_config.py
@@ -13,6 +13,7 @@ def deploy(
     indexer_client: IndexerClient,
     app_spec: algokit_utils.ApplicationSpecification,
     deployer: algokit_utils.Account,
+    version: str | None,
 ) -> None:
     from smart_contracts.artifacts.hello_world.client import (
         HelloWorldClient,
@@ -27,6 +28,8 @@ def deploy(
     app_client.deploy(
         on_schema_break=algokit_utils.OnSchemaBreak.AppendApp,
         on_update=algokit_utils.OnUpdate.AppendApp,
+        # Uncomment this next line to pin the deployment version to the project version.
+        version=version,
     )
     name = "world"
     response = app_client.hello(name=name)

--- a/examples/production_python/smart_contracts/helpers/deploy.py
+++ b/examples/production_python/smart_contracts/helpers/deploy.py
@@ -4,6 +4,7 @@
 import logging
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import (
     Account,
@@ -24,8 +25,9 @@ logger = logging.getLogger(__name__)
 def deploy(
     app_spec_path: Path,
     deploy_callback: Callable[
-        [AlgodClient, IndexerClient, ApplicationSpecification, Account], None
+        [AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None
     ],
+    version: str | None = None,
     deployer_initial_funds: int = 2,
 ) -> None:
     # get clients
@@ -50,4 +52,4 @@ def deploy(
     )
 
     # use provided callback to deploy the app
-    deploy_callback(algod_client, indexer_client, app_spec, deployer)
+    deploy_callback(algod_client, indexer_client, app_spec, deployer, version)

--- a/examples/production_python/smart_contracts/helpers/util.py
+++ b/examples/production_python/smart_contracts/helpers/util.py
@@ -1,8 +1,18 @@
 from pathlib import Path
 
+import tomllib
+
 
 def find_app_spec_file(output_dir: Path) -> str | None:
     for file in output_dir.iterdir():
         if file.is_file() and file.suffixes == [".arc32", ".json"]:
             return file.name
     return None
+
+
+def find_pyproject_version(pyproject_toml: Path) -> str | None:
+    try:
+        data = tomllib.load(open(pyproject_toml, "rb"))
+        return data.get("tool", {}).get("poetry", {}).get("version")
+    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        return None

--- a/examples/starter_python/smart_contracts/__main__.py
+++ b/examples/starter_python/smart_contracts/__main__.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from smart_contracts.config import contracts
 from smart_contracts.helpers.build import build
 from smart_contracts.helpers.deploy import deploy
-from smart_contracts.helpers.util import find_app_spec_file
+from smart_contracts.helpers.util import find_app_spec_file, find_pyproject_version
 
 # Uncomment the following lines to enable auto generation of AVM Debugger compliant sourcemap and simulation trace file.
 # Learn more about using AlgoKit AVM Debugger to debug your TEAL source codes and inspect various kinds of
@@ -27,6 +27,7 @@ root_path = Path(__file__).parent
 
 def main(action: str) -> None:
     artifact_path = root_path / "artifacts"
+    pyproject_version = find_pyproject_version(root_path.parent / "pyproject.toml")
     match action:
         case "build":
             for contract in contracts:
@@ -41,14 +42,14 @@ def main(action: str) -> None:
                     raise Exception("Could not deploy app, .arc32.json file not found")
                 app_spec_path = output_dir / app_spec_file_name
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
         case "all":
             for contract in contracts:
                 logger.info(f"Building app at {contract.path}")
                 app_spec_path = build(artifact_path / contract.name, contract.path)
                 logger.info(f"Deploying {contract.path.name}")
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
 
 
 if __name__ == "__main__":

--- a/examples/starter_python/smart_contracts/config.py
+++ b/examples/starter_python/smart_contracts/config.py
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import Account, ApplicationSpecification
 from algosdk.v2client.algod import AlgodClient
@@ -13,7 +14,7 @@ class SmartContract:
     path: Path
     name: str
     deploy: (
-        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
         | None
     ) = None
 
@@ -30,7 +31,7 @@ def import_contract(folder: Path) -> Path:
 def import_deploy_if_exists(
     folder: Path,
 ) -> (
-    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
     | None
 ):
     """Imports the deploy function from a folder if it exists."""

--- a/examples/starter_python/smart_contracts/hello_world/deploy_config.py
+++ b/examples/starter_python/smart_contracts/hello_world/deploy_config.py
@@ -13,6 +13,7 @@ def deploy(
     indexer_client: IndexerClient,
     app_spec: algokit_utils.ApplicationSpecification,
     deployer: algokit_utils.Account,
+    version: str | None,
 ) -> None:
     from smart_contracts.artifacts.hello_world.client import (
         HelloWorldClient,
@@ -27,6 +28,8 @@ def deploy(
     app_client.deploy(
         on_schema_break=algokit_utils.OnSchemaBreak.AppendApp,
         on_update=algokit_utils.OnUpdate.AppendApp,
+        # Uncomment this next line to pin the deployment version to the project version.
+        version=version,
     )
     name = "world"
     response = app_client.hello(name=name)

--- a/examples/starter_python/smart_contracts/helpers/deploy.py
+++ b/examples/starter_python/smart_contracts/helpers/deploy.py
@@ -4,6 +4,7 @@
 import logging
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import (
     Account,
@@ -24,8 +25,9 @@ logger = logging.getLogger(__name__)
 def deploy(
     app_spec_path: Path,
     deploy_callback: Callable[
-        [AlgodClient, IndexerClient, ApplicationSpecification, Account], None
+        [AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None
     ],
+    version: str | None = None,
     deployer_initial_funds: int = 2,
 ) -> None:
     # get clients
@@ -50,4 +52,4 @@ def deploy(
     )
 
     # use provided callback to deploy the app
-    deploy_callback(algod_client, indexer_client, app_spec, deployer)
+    deploy_callback(algod_client, indexer_client, app_spec, deployer, version)

--- a/examples/starter_python/smart_contracts/helpers/util.py
+++ b/examples/starter_python/smart_contracts/helpers/util.py
@@ -1,8 +1,18 @@
 from pathlib import Path
 
+import tomllib
+
 
 def find_app_spec_file(output_dir: Path) -> str | None:
     for file in output_dir.iterdir():
         if file.is_file() and file.suffixes == [".arc32", ".json"]:
             return file.name
     return None
+
+
+def find_pyproject_version(pyproject_toml: Path) -> str | None:
+    try:
+        data = tomllib.load(open(pyproject_toml, "rb"))
+        return data.get("tool", {}).get("poetry", {}).get("version")
+    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        return None

--- a/template_content/smart_contracts/__main__.py.jinja
+++ b/template_content/smart_contracts/__main__.py.jinja
@@ -8,7 +8,7 @@ from smart_contracts.config import contracts
 from smart_contracts.helpers.build import build
 {% if deployment_language == 'python' -%}
 from smart_contracts.helpers.deploy import deploy
-from smart_contracts.helpers.util import find_app_spec_file
+from smart_contracts.helpers.util import find_app_spec_file{% if deployment_language == 'python' %}, find_pyproject_version{% endif %}
 
 # Uncomment the following lines to enable auto generation of AVM Debugger compliant sourcemap and simulation trace file.
 # Learn more about using AlgoKit AVM Debugger to debug your TEAL source codes and inspect various kinds of
@@ -29,6 +29,9 @@ root_path = Path(__file__).parent
 
 def main(action: str) -> None:
     artifact_path = root_path / "artifacts"
+    {% if deployment_language == 'python' -%}
+    pyproject_version = find_pyproject_version(root_path.parent / "pyproject.toml")
+    {% endif -%}
     match action:
         case "build":
             for contract in contracts:
@@ -44,14 +47,14 @@ def main(action: str) -> None:
                     raise Exception("Could not deploy app, .arc32.json file not found")
                 app_spec_path = output_dir / app_spec_file_name
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
         case "all":
             for contract in contracts:
                 logger.info(f"Building app at {contract.path}")
                 app_spec_path = build(artifact_path / contract.name, contract.path)
                 logger.info(f"Deploying {contract.path.name}")
                 if contract.deploy:
-                    deploy(app_spec_path, contract.deploy)
+                    deploy(app_spec_path, contract.deploy, pyproject_version)
         {%- endif %}
 
 

--- a/template_content/smart_contracts/config.py.jinja
+++ b/template_content/smart_contracts/config.py.jinja
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import Account, ApplicationSpecification
 from algosdk.v2client.algod import AlgodClient
@@ -13,7 +14,7 @@ class SmartContract:
     path: Path
     name: str
     deploy: (
-        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+        Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
         | None
     ) = None
 
@@ -30,7 +31,7 @@ def import_contract(folder: Path) -> Path:
 def import_deploy_if_exists(
     folder: Path,
 ) -> (
-    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account], None]
+    Callable[[AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None]
     | None
 ):
     """Imports the deploy function from a folder if it exists."""

--- a/template_content/smart_contracts/helpers/util.py
+++ b/template_content/smart_contracts/helpers/util.py
@@ -1,8 +1,22 @@
 from pathlib import Path
 
+import tomllib
+
 
 def find_app_spec_file(output_dir: Path) -> str | None:
     for file in output_dir.iterdir():
         if file.is_file() and file.suffixes == [".arc32", ".json"]:
             return file.name
     return None
+
+
+def find_pyproject_version(pyproject_toml: Path) -> str | None:
+    with open(pyproject_toml, "rb") as f:
+        content = tomllib.load(f)
+    return (
+        content["tool"]["poetry"]["version"]
+        if "tool" in content
+        and "poetry" in content["tool"]
+        and "version" in content["tool"]["poetry"]
+        else None
+    )

--- a/template_content/smart_contracts/helpers/util.py
+++ b/template_content/smart_contracts/helpers/util.py
@@ -11,12 +11,8 @@ def find_app_spec_file(output_dir: Path) -> str | None:
 
 
 def find_pyproject_version(pyproject_toml: Path) -> str | None:
-    with open(pyproject_toml, "rb") as f:
-        content = tomllib.load(f)
-    return (
-        content["tool"]["poetry"]["version"]
-        if "tool" in content
-        and "poetry" in content["tool"]
-        and "version" in content["tool"]["poetry"]
-        else None
-    )
+    try:
+        data = tomllib.load(open(pyproject_toml, "rb"))
+        return data.get("tool", {}).get("poetry", {}).get("version")
+    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        return None

--- a/template_content/smart_contracts/helpers/{% if deployment_language == 'python' %}deploy.py{% endif %}.jinja
+++ b/template_content/smart_contracts/helpers/{% if deployment_language == 'python' %}deploy.py{% endif %}.jinja
@@ -4,6 +4,7 @@
 import logging
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from algokit_utils import (
     Account,
@@ -24,8 +25,9 @@ logger = logging.getLogger(__name__)
 def deploy(
     app_spec_path: Path,
     deploy_callback: Callable[
-        [AlgodClient, IndexerClient, ApplicationSpecification, Account], None
+        [AlgodClient, IndexerClient, ApplicationSpecification, Account, Optional[str]], None
     ],
+    version: str | None = None,
     deployer_initial_funds: int = 2,
 ) -> None:
     # get clients
@@ -50,4 +52,4 @@ def deploy(
     )
 
     # use provided callback to deploy the app
-    deploy_callback(algod_client, indexer_client, app_spec, deployer)
+    deploy_callback(algod_client, indexer_client, app_spec, deployer, version)

--- a/template_content/smart_contracts/{{ contract_name }}/{% if deployment_language == 'python' %}deploy_config.py{% endif %}.jinja
+++ b/template_content/smart_contracts/{{ contract_name }}/{% if deployment_language == 'python' %}deploy_config.py{% endif %}.jinja
@@ -13,6 +13,7 @@ def deploy(
     indexer_client: IndexerClient,
     app_spec: algokit_utils.ApplicationSpecification,
     deployer: algokit_utils.Account,
+    version: str | None,
 ) -> None:
     from smart_contracts.artifacts.{{ contract_name }}.client import (
         {% include pathjoin('includes', 'contract_name_pascal.jinja') %}Client,
@@ -27,6 +28,8 @@ def deploy(
     app_client.deploy(
         on_schema_break=algokit_utils.OnSchemaBreak.AppendApp,
         on_update=algokit_utils.OnUpdate.AppendApp,
+        # Uncomment this next line to pin the deployment version to the project version.
+        version=version,
     )
     name = "world"
     response = app_client.hello(name=name)


### PR DESCRIPTION
This PR proposes modifying the template to allow the user to pin the deployment version to the project version.
The user would enable this feature by un-commenting a single line in `deployment_config.py` for each contract that they want to pin.
We resorted to reading the project version from `pyproject.toml` using `tomllib` (and not by installing an editable version in the local `venv`) because a TS deployer cannot access the version that way. Parsing the TOML makes more sense from a code parity standpoint.

At the point of writing this PR, the version is a string that is not used to determine if a deploy should result in an update/replace/append action.

This is still a work in progress. Items missing are:
- Version pin at project level vs per each smart contract
- Untyped dictionary from `tomllib` makes `mypy` complain
- Determine if this version pin only makes sense for non-local networks (seen as the most likely scenario for LocalNet is that people deploy a new iteration of the contract without changing the project version) (this shouldn't be an issue because the version does not influence a deploy action)
- TS deployer