### PR TITLE
chore: disable verbose compile for more consistent output stability

### DIFF
--- a/examples/generators/production_python_smart_contract_python/README.md
+++ b/examples/generators/production_python_smart_contract_python/README.md
@@ -123,8 +123,10 @@ For pull requests and pushes to `main` branch against this repository the follow
 - - `Algorand Python` smart contract unit tests, that are run using [`algorand-python-testing`](https://pypi.org/project/algorand-python-testing/), which are executed in a Python intepreter emulating major AVM behaviour
 - - Python `ApplicationClient` tests that are run against `algokit localnet` and test the behaviour in a real network enviornment
  - Smart contract artifacts are built
- - Smart contract artifacts are checked for [output stability](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/articles/output_stability.md)
+ - Smart contract artifacts are checked for [output stability](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/articles/output_stability.md).
  - Smart contract is deployed to a AlgoKit LocalNet instance
+
+> NOTE: By default smart contract artifacts are compiled with `--debug-level` set to 0, to change this, modify the compiler invocation under `smart_contracts/_helpers/build.py`
 
 #### Continuous Deployment
 

--- a/examples/generators/production_python_smart_contract_python/smart_contracts/_helpers/build.py
+++ b/examples/generators/production_python_smart_contract_python/smart_contracts/_helpers/build.py
@@ -31,6 +31,7 @@ def build(output_dir: Path, contract_path: Path) -> Path:
             contract_path.absolute(),
             f"--out-dir={output_dir}",
             "--output-arc32",
+            "--debug-level=0",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/examples/generators/production_python_smart_contract_typescript/README.md
+++ b/examples/generators/production_python_smart_contract_typescript/README.md
@@ -122,8 +122,10 @@ For pull requests and pushes to `main` branch against this repository the follow
  - Types are checked using [mypy](https://mypy-lang.org/)
  - Typescript `ApplicationClient` tests against `algokit localnet` are executed using [jest](https://jestjs.io/)
  - Smart contract artifacts are built
- - Smart contract artifacts are checked for [output stability](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/articles/output_stability.md)
+ - Smart contract artifacts are checked for [output stability](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/articles/output_stability.md).
  - Smart contract is deployed to a AlgoKit LocalNet instance
+
+> NOTE: By default smart contract artifacts are compiled with `--debug-level` set to 0, to change this, modify the compiler invocation under `smart_contracts/_helpers/build.py`
 
 #### Continuous Deployment
 

--- a/examples/generators/production_python_smart_contract_typescript/smart_contracts/_helpers/build.py
+++ b/examples/generators/production_python_smart_contract_typescript/smart_contracts/_helpers/build.py
@@ -31,6 +31,7 @@ def build(output_dir: Path, contract_path: Path) -> Path:
             contract_path.absolute(),
             f"--out-dir={output_dir}",
             "--output-arc32",
+            "--debug-level=0",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/examples/generators/starter_python_smart_contract_python/smart_contracts/_helpers/build.py
+++ b/examples/generators/starter_python_smart_contract_python/smart_contracts/_helpers/build.py
@@ -31,6 +31,7 @@ def build(output_dir: Path, contract_path: Path) -> Path:
             contract_path.absolute(),
             f"--out-dir={output_dir}",
             "--output-arc32",
+            "--debug-level=0",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/examples/generators/starter_python_smart_contract_typescript/smart_contracts/_helpers/build.py
+++ b/examples/generators/starter_python_smart_contract_typescript/smart_contracts/_helpers/build.py
@@ -31,6 +31,7 @@ def build(output_dir: Path, contract_path: Path) -> Path:
             contract_path.absolute(),
             f"--out-dir={output_dir}",
             "--output-arc32",
+            "--debug-level=0",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/examples/production_python/README.md
+++ b/examples/production_python/README.md
@@ -123,8 +123,10 @@ For pull requests and pushes to `main` branch against this repository the follow
 - - `Algorand Python` smart contract unit tests, that are run using [`algorand-python-testing`](https://pypi.org/project/algorand-python-testing/), which are executed in a Python intepreter emulating major AVM behaviour
 - - Python `ApplicationClient` tests that are run against `algokit localnet` and test the behaviour in a real network enviornment
  - Smart contract artifacts are built
- - Smart contract artifacts are checked for [output stability](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/articles/output_stability.md)
+ - Smart contract artifacts are checked for [output stability](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/articles/output_stability.md).
  - Smart contract is deployed to a AlgoKit LocalNet instance
+
+> NOTE: By default smart contract artifacts are compiled with `--debug-level` set to 0, to change this, modify the compiler invocation under `smart_contracts/_helpers/build.py`
 
 #### Continuous Deployment
 

--- a/examples/production_python/smart_contracts/_helpers/build.py
+++ b/examples/production_python/smart_contracts/_helpers/build.py
@@ -31,6 +31,7 @@ def build(output_dir: Path, contract_path: Path) -> Path:
             contract_path.absolute(),
             f"--out-dir={output_dir}",
             "--output-arc32",
+            "--debug-level=0",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/examples/starter_python/smart_contracts/_helpers/build.py
+++ b/examples/starter_python/smart_contracts/_helpers/build.py
@@ -31,6 +31,7 @@ def build(output_dir: Path, contract_path: Path) -> Path:
             contract_path.absolute(),
             f"--out-dir={output_dir}",
             "--output-arc32",
+            "--debug-level=0",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/template_content/README.md.jinja
+++ b/template_content/README.md.jinja
@@ -154,8 +154,10 @@ For pull requests and pushes to `main` branch against this repository the follow
  - Typescript `ApplicationClient` tests against `algokit localnet` are executed using [jest](https://jestjs.io/)
 {%- endif %}
  - Smart contract artifacts are built
- - Smart contract artifacts are checked for [output stability](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/articles/output_stability.md)
+ - Smart contract artifacts are checked for [output stability](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/articles/output_stability.md).
  - Smart contract is deployed to a AlgoKit LocalNet instance
+
+> NOTE: By default smart contract artifacts are compiled with `--debug-level` set to 0, to change this, modify the compiler invocation under `smart_contracts/_helpers/build.py`
 
 #### Continuous Deployment
 

--- a/template_content/smart_contracts/_helpers/build.py.jinja
+++ b/template_content/smart_contracts/_helpers/build.py.jinja
@@ -34,6 +34,7 @@ def build(output_dir: Path, contract_path: Path) -> Path:
             contract_path.absolute(),
             f"--out-dir={output_dir}",
             "--output-arc32",
+            "--debug-level=0",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
## Proposed Changes

- Setting debug level to 0 to ensure puya isn't generating verbose teal artifacts by default
- Updating root readme to explain how to control that behavior for scenarios post-init
