### PR TITLE
fix: enforces poetry setting to prefer active python instance

### DIFF
--- a/examples/generators/production_python_smart_contract_python/poetry.toml
+++ b/examples/generators/production_python_smart_contract_python/poetry.toml
@@ -1,2 +1,3 @@
 [virtualenvs]
 in-project = true
+prefer-active-python = true

--- a/examples/generators/production_python_smart_contract_typescript/poetry.toml
+++ b/examples/generators/production_python_smart_contract_typescript/poetry.toml
@@ -1,2 +1,3 @@
 [virtualenvs]
 in-project = true
+prefer-active-python = true

--- a/examples/generators/starter_python_smart_contract_python/poetry.toml
+++ b/examples/generators/starter_python_smart_contract_python/poetry.toml
@@ -1,2 +1,3 @@
 [virtualenvs]
 in-project = true
+prefer-active-python = true

--- a/examples/generators/starter_python_smart_contract_typescript/poetry.toml
+++ b/examples/generators/starter_python_smart_contract_typescript/poetry.toml
@@ -1,2 +1,3 @@
 [virtualenvs]
 in-project = true
+prefer-active-python = true

--- a/examples/production_python/poetry.toml
+++ b/examples/production_python/poetry.toml
@@ -1,2 +1,3 @@
 [virtualenvs]
 in-project = true
+prefer-active-python = true

--- a/examples/starter_python/poetry.toml
+++ b/examples/starter_python/poetry.toml
@@ -1,2 +1,3 @@
 [virtualenvs]
 in-project = true
+prefer-active-python = true

--- a/template_content/poetry.toml
+++ b/template_content/poetry.toml
@@ -1,2 +1,3 @@
 [virtualenvs]
 in-project = true
+prefer-active-python = true


### PR DESCRIPTION
## Proposed Changes

- adds a setting to enforce using active python version over the version used to install poetry. 