### PR TITLE
chore: utils-py version bump

### DIFF
--- a/examples/generators/production_python_smart_contract_python/pyproject.toml
+++ b/examples/generators/production_python_smart_contract_python/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-algokit-utils = "^2.3.0"
+algokit-utils = "^2.4.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
 algorand-python-testing = "^0.4.0"

--- a/examples/generators/production_python_smart_contract_typescript/pyproject.toml
+++ b/examples/generators/production_python_smart_contract_typescript/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-algokit-utils = "^2.3.0"
+algokit-utils = "^2.4.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
 algorand-python-testing = "^0.4.0"

--- a/examples/generators/starter_python_smart_contract_python/pyproject.toml
+++ b/examples/generators/starter_python_smart_contract_python/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-algokit-utils = "^2.3.0"
+algokit-utils = "^2.4.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
 algorand-python-testing = "^0.4.0"

--- a/examples/generators/starter_python_smart_contract_typescript/pyproject.toml
+++ b/examples/generators/starter_python_smart_contract_typescript/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-algokit-utils = "^2.3.0"
+algokit-utils = "^2.4.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
 algorand-python-testing = "^0.4.0"

--- a/examples/production_python/pyproject.toml
+++ b/examples/production_python/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-algokit-utils = "^2.3.0"
+algokit-utils = "^2.4.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
 algorand-python-testing = "^0.4.0"

--- a/examples/starter_python/pyproject.toml
+++ b/examples/starter_python/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-algokit-utils = "^2.3.0"
+algokit-utils = "^2.4.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
 algorand-python-testing = "^0.4.0"

--- a/template_content/pyproject.toml.jinja
+++ b/template_content/pyproject.toml.jinja
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-algokit-utils = "^2.3.0"
+algokit-utils = "^2.4.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
 algorand-python-testing = "^0.4.0"


### PR DESCRIPTION
## Proposed Changes

- Bumping to latest utils-py version that introduces support for better support puya debugging and deprecates persist sourcemaps method (which is now handled by vscode extension directly)