### PR TITLE
fix: minor pre commit typo; mypy tweaks for algosdk

### DIFF
--- a/examples/generators/production_python_smart_contract_python/.pre-commit-config.yaml
+++ b/examples/generators/production_python_smart_contract_python/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         require_serial: false
         additional_dependencies: [ ]
         minimum_pre_commit_version: '0'
-        files: '^(src|tests)/'
+        files: '^(smart_contracts|tests)/'
       
       
       - id: mypy
@@ -34,7 +34,7 @@ repos:
         require_serial: true
         additional_dependencies: [ ]
         minimum_pre_commit_version: '2.9.2'
-        files: '^(src|tests)/'
+        files: '^(smart_contracts|tests)/'
       
       # # Uncomment to enable TEAL static analysis using Tealer package
       # - id: tealer

--- a/examples/generators/production_python_smart_contract_python/pyproject.toml
+++ b/examples/generators/production_python_smart_contract_python/pyproject.toml
@@ -62,3 +62,9 @@ disallow_any_unimported = true
 disallow_any_expr = true
 disallow_any_decorated = true
 disallow_any_explicit = true
+untyped_calls_exclude = ["algosdk"]
+# Remove if you prefer to use mypy's default behavior against 
+# untyped algosdk types
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_any_expr = false

--- a/examples/generators/production_python_smart_contract_typescript/.pre-commit-config.yaml
+++ b/examples/generators/production_python_smart_contract_typescript/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         require_serial: false
         additional_dependencies: [ ]
         minimum_pre_commit_version: '0'
-        files: '^(src|tests)/'
+        files: '^(smart_contracts|tests)/'
       
       
       - id: mypy
@@ -34,7 +34,7 @@ repos:
         require_serial: true
         additional_dependencies: [ ]
         minimum_pre_commit_version: '2.9.2'
-        files: '^(src|tests)/'
+        files: '^(smart_contracts|tests)/'
       
       # # Uncomment to enable TEAL static analysis using Tealer package
       # - id: tealer

--- a/examples/generators/production_python_smart_contract_typescript/pyproject.toml
+++ b/examples/generators/production_python_smart_contract_typescript/pyproject.toml
@@ -56,3 +56,9 @@ disallow_any_unimported = true
 disallow_any_expr = true
 disallow_any_decorated = true
 disallow_any_explicit = true
+untyped_calls_exclude = ["algosdk"]
+# Remove if you prefer to use mypy's default behavior against 
+# untyped algosdk types
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_any_expr = false

--- a/examples/production_python/.pre-commit-config.yaml
+++ b/examples/production_python/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         require_serial: false
         additional_dependencies: [ ]
         minimum_pre_commit_version: '0'
-        files: '^(src|tests)/'
+        files: '^(smart_contracts|tests)/'
       
       
       - id: mypy
@@ -34,7 +34,7 @@ repos:
         require_serial: true
         additional_dependencies: [ ]
         minimum_pre_commit_version: '2.9.2'
-        files: '^(src|tests)/'
+        files: '^(smart_contracts|tests)/'
       
       # # Uncomment to enable TEAL static analysis using Tealer package
       # - id: tealer

--- a/examples/production_python/pyproject.toml
+++ b/examples/production_python/pyproject.toml
@@ -62,3 +62,9 @@ disallow_any_unimported = true
 disallow_any_expr = true
 disallow_any_decorated = true
 disallow_any_explicit = true
+untyped_calls_exclude = ["algosdk"]
+# Remove if you prefer to use mypy's default behavior against 
+# untyped algosdk types
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_any_expr = false

--- a/template_content/pyproject.toml.jinja
+++ b/template_content/pyproject.toml.jinja
@@ -81,4 +81,10 @@ disallow_any_unimported = true
 disallow_any_expr = true
 disallow_any_decorated = true
 disallow_any_explicit = true
+untyped_calls_exclude = ["algosdk"]
+# Remove if you prefer to use mypy's default behavior against 
+# untyped algosdk types
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_any_expr = false
 {% endif -%}

--- a/template_content/{% if use_pre_commit %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template_content/{% if use_pre_commit %}.pre-commit-config.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ repos:
         require_serial: false
         additional_dependencies: [ ]
         minimum_pre_commit_version: '0'
-        files: '^(src|tests)/'
+        files: '^(smart_contracts|tests)/'
       {% endif %}
       {% if use_python_mypy %}
       - id: mypy
@@ -34,7 +34,7 @@ repos:
         require_serial: true
         additional_dependencies: [ ]
         minimum_pre_commit_version: '2.9.2'
-        files: '^(src|tests)/'
+        files: '^(smart_contracts|tests)/'
       {% endif %}
       # # Uncomment to enable TEAL static analysis using Tealer package
       # - id: tealer


### PR DESCRIPTION
## Proposed Changes

Addresses a few minor items reported by @cusma

- Fixes typo in pre-commit template
- Allows untyped algosdk calls in tests folder, as algosdk is largely untyped
