### PR TITLE
fix: updates algorand-python-testing dependency to support latest algopy Array and ImmutableArray stubs

### DIFF
--- a/examples/generators/production_python_smart_contract_python/pyproject.toml
+++ b/examples/generators/production_python_smart_contract_python/pyproject.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "Algorand smart contracts"
 authors = ["None <None>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
-algorand-python-testing = "^0.4.0"
+algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]
 algokit-client-generator = "^2.1.0"

--- a/examples/generators/production_python_smart_contract_typescript/pyproject.toml
+++ b/examples/generators/production_python_smart_contract_typescript/pyproject.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "Algorand smart contracts"
 authors = ["None <None>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
-algorand-python-testing = "^0.4.0"
+algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]
 black = {extras = ["d"], version = "*"}

--- a/examples/generators/starter_python_smart_contract_python/pyproject.toml
+++ b/examples/generators/starter_python_smart_contract_python/pyproject.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "Algorand smart contracts"
 authors = ["None <None>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
-algorand-python-testing = "^0.4.0"
+algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]
 algokit-client-generator = "^2.1.0"

--- a/examples/generators/starter_python_smart_contract_typescript/pyproject.toml
+++ b/examples/generators/starter_python_smart_contract_typescript/pyproject.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "Algorand smart contracts"
 authors = ["None <None>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
-algorand-python-testing = "^0.4.0"
+algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]
 puyapy = "*"

--- a/examples/production_python/pyproject.toml
+++ b/examples/production_python/pyproject.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "Algorand smart contracts"
 authors = ["None <None>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
-algorand-python-testing = "^0.4.0"
+algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]
 algokit-client-generator = "^2.1.0"

--- a/examples/starter_python/pyproject.toml
+++ b/examples/starter_python/pyproject.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "Algorand smart contracts"
 authors = ["None <None>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
-algorand-python-testing = "^0.4.0"
+algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]
 algokit-client-generator = "^2.1.0"

--- a/template_content/pyproject.toml.jinja
+++ b/template_content/pyproject.toml.jinja
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "Algorand smart contracts"
 authors = ["{{ author_name }} <{{ author_email }}>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
 algorand-python = "^2.0.0"
-algorand-python-testing = "^0.4.0"
+algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]
 {% if deployment_language == 'python' -%}


### PR DESCRIPTION
Updates the `algorand-python-testing` dependency version constraint to allow for patch updates.
Also, adds `package-mode = false` to avoid poetry packaging issues in v2.

Original issue was suspected to be on the unit testing repo https://github.com/algorandfoundation/algorand-python-testing/issues/38 but ended up being an issue with the version on the template repo. PR modifies the version specifier to ensure it picks up latest zero versioned version of unit testing package.
