### PR TITLE
fix: make localnet default without mnemonic prompt when running deploy

### DIFF
--- a/examples/generators/production_python_smart_contract_python/.algokit.toml
+++ b/examples/generators/production_python_smart_contract_python/.algokit.toml
@@ -16,13 +16,18 @@ artifacts = 'smart_contracts/artifacts'
 
 [project.deploy]
 command = "poetry run python -m smart_contracts deploy"
+
+[project.deploy.testnet]
 environment_secrets = [
   "DEPLOYER_MNEMONIC",
   "DISPENSER_MNEMONIC",
 ]
 
-[project.deploy.localnet]
-environment_secrets = []
+[project.deploy.mainnet]
+environment_secrets = [
+  "DEPLOYER_MNEMONIC",
+  "DISPENSER_MNEMONIC",
+]
 
 [project.run]
 # Commands intented for use locally and in CI

--- a/examples/generators/production_python_smart_contract_typescript/.algokit.toml
+++ b/examples/generators/production_python_smart_contract_typescript/.algokit.toml
@@ -16,13 +16,18 @@ artifacts = 'smart_contracts/artifacts'
 
 [project.deploy]
 command = "npm run deploy:ci"
+
+[project.deploy.testnet]
 environment_secrets = [
   "DEPLOYER_MNEMONIC",
   "DISPENSER_MNEMONIC",
 ]
 
-[project.deploy.localnet]
-environment_secrets = []
+[project.deploy.mainnet]
+environment_secrets = [
+  "DEPLOYER_MNEMONIC",
+  "DISPENSER_MNEMONIC",
+]
 
 [project.run]
 # Commands intented for use locally and in CI

--- a/examples/generators/starter_python_smart_contract_python/.algokit.toml
+++ b/examples/generators/starter_python_smart_contract_python/.algokit.toml
@@ -16,12 +16,16 @@ artifacts = 'smart_contracts/artifacts'
 
 [project.deploy]
 command = "poetry run python -m smart_contracts deploy"
+
+[project.deploy.testnet]
 environment_secrets = [
   "DEPLOYER_MNEMONIC",
 ]
 
-[project.deploy.localnet]
-environment_secrets = []
+[project.deploy.mainnet]
+environment_secrets = [
+  "DEPLOYER_MNEMONIC",
+]
 
 [project.run]
 # Commands intented for use locally and in CI

--- a/examples/generators/starter_python_smart_contract_typescript/.algokit.toml
+++ b/examples/generators/starter_python_smart_contract_typescript/.algokit.toml
@@ -16,12 +16,16 @@ artifacts = 'smart_contracts/artifacts'
 
 [project.deploy]
 command = "npm run deploy:ci"
+
+[project.deploy.testnet]
 environment_secrets = [
   "DEPLOYER_MNEMONIC",
 ]
 
-[project.deploy.localnet]
-environment_secrets = []
+[project.deploy.mainnet]
+environment_secrets = [
+  "DEPLOYER_MNEMONIC",
+]
 
 [project.run]
 # Commands intented for use locally and in CI

--- a/examples/production_python/.algokit.toml
+++ b/examples/production_python/.algokit.toml
@@ -16,13 +16,18 @@ artifacts = 'smart_contracts/artifacts'
 
 [project.deploy]
 command = "poetry run python -m smart_contracts deploy"
+
+[project.deploy.testnet]
 environment_secrets = [
   "DEPLOYER_MNEMONIC",
   "DISPENSER_MNEMONIC",
 ]
 
-[project.deploy.localnet]
-environment_secrets = []
+[project.deploy.mainnet]
+environment_secrets = [
+  "DEPLOYER_MNEMONIC",
+  "DISPENSER_MNEMONIC",
+]
 
 [project.run]
 # Commands intented for use locally and in CI

--- a/examples/starter_python/.algokit.toml
+++ b/examples/starter_python/.algokit.toml
@@ -16,12 +16,16 @@ artifacts = 'smart_contracts/artifacts'
 
 [project.deploy]
 command = "poetry run python -m smart_contracts deploy"
+
+[project.deploy.testnet]
 environment_secrets = [
   "DEPLOYER_MNEMONIC",
 ]
 
-[project.deploy.localnet]
-environment_secrets = []
+[project.deploy.mainnet]
+environment_secrets = [
+  "DEPLOYER_MNEMONIC",
+]
 
 [project.run]
 # Commands intented for use locally and in CI

--- a/template_content/.algokit.toml.jinja
+++ b/template_content/.algokit.toml.jinja
@@ -20,6 +20,8 @@ command = "poetry run python -m smart_contracts deploy"
 {%- elif deployment_language == 'typescript' %}
 command = "npm run deploy:ci"
 {%- endif %}
+
+[project.deploy.testnet]
 environment_secrets = [
   "DEPLOYER_MNEMONIC",
 {%- if use_dispenser %}
@@ -27,8 +29,13 @@ environment_secrets = [
 {%- endif %}
 ]
 
-[project.deploy.localnet]
-environment_secrets = []
+[project.deploy.mainnet]
+environment_secrets = [
+  "DEPLOYER_MNEMONIC",
+{%- if use_dispenser %}
+  "DISPENSER_MNEMONIC",
+{%- endif %}
+]
 
 [project.run]
 # Commands intented for use locally and in CI


### PR DESCRIPTION
The PR fixes an issue that @SilentRhetoric reported.

When running `algokit project deploy` without an environment specified it prompts for a `DEPLOYER_MNEMONIC`. This isn't needed when deploying to localnet, which will be the default network.

This change will also be propagated to the other templates, however if a project has already been created, that'll project will need to be updated manually.