### PR TITLE
Bump algorand-python to ^3.0 everywhere

### DIFF
--- a/examples/generators/production_python_smart_contract_python/pyproject.toml
+++ b/examples/generators/production_python_smart_contract_python/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = false
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
-algorand-python = "^2.0.0"
+algorand-python = "^3.0.0"
 algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/generators/production_python_smart_contract_typescript/pyproject.toml
+++ b/examples/generators/production_python_smart_contract_typescript/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = false
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
-algorand-python = "^2.0.0"
+algorand-python = "^3.0.0"
 algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/generators/starter_python_smart_contract_python/pyproject.toml
+++ b/examples/generators/starter_python_smart_contract_python/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = false
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
-algorand-python = "^2.0.0"
+algorand-python = "^3.0.0"
 algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/generators/starter_python_smart_contract_typescript/pyproject.toml
+++ b/examples/generators/starter_python_smart_contract_typescript/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = false
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
-algorand-python = "^2.0.0"
+algorand-python = "^3.0.0"
 algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/production_python/pyproject.toml
+++ b/examples/production_python/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = false
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
-algorand-python = "^2.0.0"
+algorand-python = "^3.0.0"
 algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/starter_python/pyproject.toml
+++ b/examples/starter_python/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = false
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
-algorand-python = "^2.0.0"
+algorand-python = "^3.0.0"
 algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]

--- a/template_content/pyproject.toml.jinja
+++ b/template_content/pyproject.toml.jinja
@@ -10,7 +10,7 @@ package-mode = false
 python = "^3.12"
 algokit-utils = "^4.0.0"
 python-dotenv = "^1.0.0"
-algorand-python = "^2.0.0"
+algorand-python = "^3.0.0"
 algorand-python-testing = "~0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Updating version number in all independant pyproject files after puyapy 5.0 and algorand-python 3.0 release.